### PR TITLE
[WIP] PoC: explicit registration of Actions in TransportAction and NodeClient

### DIFF
--- a/modules/reindex/src/main/java/org/elasticsearch/reindex/ReindexPlugin.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/reindex/ReindexPlugin.java
@@ -12,6 +12,9 @@ import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.admin.cluster.node.tasks.list.ListTasksResponse;
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.ActionRegistrar;
+import org.elasticsearch.action.support.ActionServices;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
@@ -55,6 +58,22 @@ public class ReindexPlugin extends Plugin implements ActionPlugin {
             new ActionHandler<>(DeleteByQueryAction.INSTANCE, TransportDeleteByQueryAction.class),
             new ActionHandler<>(RETHROTTLE_ACTION, TransportRethrottleAction.class)
         );
+    }
+
+    @Override
+    public void registerActions(ActionFilters actionFilters, ActionServices services, ActionRegistrar actionRegistrar) {
+        TransportReindexAction.createAndRegister(
+            services.environment().settings(),
+            services.threadPool(),
+            actionFilters,
+            services.indexNameExpressionResolver(),
+            services.clusterService(),
+            services.scriptService(),
+            null, // TODO
+            services.client(),
+            services.transportService(),
+            new ReindexSslConfig(services.environment().settings(), services.environment(), services.resourceWatcherService()),
+            actionRegistrar);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/TransportGetFieldMappingsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/TransportGetFieldMappingsAction.java
@@ -10,15 +10,13 @@ package org.elasticsearch.action.admin.indices.mapping.get;
 
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
-import org.elasticsearch.action.support.HandledTransportAction;
+import org.elasticsearch.action.support.TransportAction;
 import org.elasticsearch.client.internal.node.NodeClient;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.service.ClusterService;
-import org.elasticsearch.common.inject.Inject;
-import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.tasks.Task;
-import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.tasks.TaskManager;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -28,27 +26,20 @@ import java.util.concurrent.atomic.AtomicReferenceArray;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.unmodifiableMap;
 
-public class TransportGetFieldMappingsAction extends HandledTransportAction<GetFieldMappingsRequest, GetFieldMappingsResponse> {
+public class TransportGetFieldMappingsAction extends TransportAction<GetFieldMappingsRequest, GetFieldMappingsResponse> {
 
     private final ClusterService clusterService;
     private final IndexNameExpressionResolver indexNameExpressionResolver;
     private final NodeClient client;
 
-    @Inject
     public TransportGetFieldMappingsAction(
-        TransportService transportService,
+        TaskManager taskManager,
         ClusterService clusterService,
         ActionFilters actionFilters,
         IndexNameExpressionResolver indexNameExpressionResolver,
         NodeClient client
     ) {
-        super(
-            GetFieldMappingsAction.NAME,
-            transportService,
-            actionFilters,
-            GetFieldMappingsRequest::new,
-            EsExecutors.DIRECT_EXECUTOR_SERVICE
-        );
+        super(GetFieldMappingsAction.NAME, actionFilters, taskManager);
         this.clusterService = clusterService;
         this.indexNameExpressionResolver = indexNameExpressionResolver;
         this.client = client;

--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/TransportFieldCapabilitiesAction.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/TransportFieldCapabilitiesAction.java
@@ -92,12 +92,6 @@ public class TransportFieldCapabilitiesAction extends RegistrableTransportAction
         this.clusterService = clusterService;
         this.indexNameExpressionResolver = indexNameExpressionResolver;
         this.indicesService = indicesService;
-        transportService.registerRequestHandler(
-            ACTION_NODE_NAME,
-            this.searchCoordinationExecutor,
-            FieldCapabilitiesNodeRequest::new,
-            new NodeTransportHandler()
-        );
         this.ccsCheckCompatibility = SearchService.CCS_VERSION_CHECK_SETTING.get(clusterService.getSettings());
     }
 

--- a/server/src/main/java/org/elasticsearch/action/support/ActionRegistrar.java
+++ b/server/src/main/java/org/elasticsearch/action/support/ActionRegistrar.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.action.support;
+
+import org.elasticsearch.action.ActionRequest;
+import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.action.ActionType;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.transport.TransportRequestHandler;
+
+import java.util.concurrent.Executor;
+
+public interface ActionRegistrar {
+
+    <Request extends ActionRequest> void registerTransport(
+        TransportAction<Request, ? extends ActionResponse> transportAction,
+        Executor executor,
+        Writeable.Reader<Request> requestReader,
+        TransportRequestHandler<Request> handler);
+
+    <Response extends ActionResponse> void registerClient(
+        ActionType<Response> actionType,
+        TransportAction<? extends ActionRequest, Response> transportAction,
+        Executor executor);
+}

--- a/server/src/main/java/org/elasticsearch/action/support/ActionServices.java
+++ b/server/src/main/java/org/elasticsearch/action/support/ActionServices.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.action.support;
+
+import org.elasticsearch.action.search.SearchTransportService;
+import org.elasticsearch.client.internal.node.NodeClient;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.env.Environment;
+import org.elasticsearch.indices.IndicesService;
+import org.elasticsearch.node.NodeService;
+import org.elasticsearch.script.ScriptService;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.watcher.ResourceWatcherService;
+
+public interface ActionServices {
+    ClusterService clusterService();
+
+    ThreadPool threadPool();
+
+    TransportService transportService();
+
+    NodeService nodeService();
+
+    SearchTransportService searchTransportService();
+
+    NodeClient client();
+
+    IndexNameExpressionResolver indexNameExpressionResolver();
+
+    IndicesService indicesService();
+
+    ScriptService scriptService();
+
+    Environment environment();
+
+    ResourceWatcherService resourceWatcherService();
+}

--- a/server/src/main/java/org/elasticsearch/action/support/RegistrableTransportAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/RegistrableTransportAction.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.action.support;
+
+import org.elasticsearch.action.ActionRequest;
+import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.action.ActionType;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.tasks.TaskManager;
+import org.elasticsearch.transport.TransportRequestHandler;
+
+import java.util.concurrent.Executor;
+
+public abstract class RegistrableTransportAction<Request extends ActionRequest, Response extends ActionResponse> extends TransportAction<
+    Request,
+    Response> {
+    protected RegistrableTransportAction(String actionName, ActionFilters actionFilters, TaskManager taskManager) {
+        super(actionName, actionFilters, taskManager);
+    }
+
+    public interface TransportActionRegister {
+        <Request extends ActionRequest> void register(
+            String actionName,
+            Executor executor,
+            Writeable.Reader<Request> requestReader,
+            TransportRequestHandler<Request> handler
+        );
+    }
+
+    public interface ClientActionRegister {
+        void register(ActionType<? extends ActionResponse> actionType, Executor executor);
+    }
+
+    // TODO: these can be 2 separate interfaces
+    public abstract void registerWithTransport(TransportActionRegister register);
+
+    public abstract void registerWithNodeClient(ClientActionRegister register);
+}

--- a/server/src/main/java/org/elasticsearch/node/Actions.java
+++ b/server/src/main/java/org/elasticsearch/node/Actions.java
@@ -1,0 +1,278 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.node;
+
+import org.elasticsearch.action.ActionRequest;
+import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.admin.cluster.node.info.TransportNodesInfoAction;
+import org.elasticsearch.action.admin.cluster.node.stats.TransportNodesStatsAction;
+import org.elasticsearch.action.admin.cluster.remote.RemoteClusterNodesAction;
+import org.elasticsearch.action.admin.cluster.remote.TransportRemoteInfoAction;
+import org.elasticsearch.action.admin.indices.mapping.get.GetFieldMappingsAction;
+import org.elasticsearch.action.admin.indices.mapping.get.GetFieldMappingsRequest;
+import org.elasticsearch.action.admin.indices.mapping.get.TransportGetFieldMappingsAction;
+import org.elasticsearch.action.fieldcaps.TransportFieldCapabilitiesAction;
+import org.elasticsearch.action.search.SearchTransportService;
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.ChannelActionListener;
+import org.elasticsearch.action.support.RegistrableTransportAction;
+import org.elasticsearch.action.support.TransportAction;
+import org.elasticsearch.client.internal.node.NodeClient;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
+import org.elasticsearch.indices.IndicesService;
+import org.elasticsearch.plugins.ActionPlugin;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportRequestHandler;
+import org.elasticsearch.transport.TransportService;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Executor;
+import java.util.function.Consumer;
+
+import static java.util.Collections.unmodifiableMap;
+
+class Actions {
+
+    interface ActionServices {
+        ClusterService clusterService();
+
+        ThreadPool threadPool();
+
+        TransportService transportService();
+
+        NodeService nodeService();
+
+        SearchTransportService searchTransportService();
+
+        NodeClient client();
+
+        IndexNameExpressionResolver indexNameExpressionResolver();
+
+        IndicesService indicesService();
+    }
+
+    static Map<ActionType<? extends ActionResponse>, TransportAction<? extends ActionRequest, ? extends ActionResponse>> setupActions(
+        List<ActionPlugin> actionPlugins,
+        ActionFilters actionFilters,
+        ActionServices services
+    ) {
+        // STEP 1: get rid of injection for NodeClient creation.
+        // Instead of using the injection mechanism as in ActionModule, we create the instances directly and push them into the
+        // Action map needed by NodeClient
+        var actions = new HashMap<
+            ActionType<? extends ActionResponse>,
+            TransportAction<? extends ActionRequest, ? extends ActionResponse>>();
+
+        actions.put(
+            TransportNodesInfoAction.TYPE,
+            new TransportNodesInfoAction(
+                services.threadPool(),
+                services.clusterService(),
+                services.transportService(),
+                services.nodeService(),
+                actionFilters
+            )
+        );
+        actions.put(
+            TransportRemoteInfoAction.TYPE,
+            new TransportRemoteInfoAction(services.transportService(), actionFilters, services.searchTransportService())
+        );
+        actions.put(
+            RemoteClusterNodesAction.TYPE,
+            new RemoteClusterNodesAction.TransportAction(services.transportService(), actionFilters, services.client())
+        );
+        actions.put(
+            TransportNodesStatsAction.TYPE,
+            new TransportNodesStatsAction(
+                services.threadPool(),
+                services.clusterService(),
+                services.transportService(),
+                services.nodeService(),
+                actionFilters
+            )
+        );
+        // ... and so on
+
+        // STEP 2: put NodeClient and TransportService action registration together, in the same place
+
+        // SOLUTION 1: registration code inside this class.
+        // Code in HandledTransportAction will be moved here - HandledTransportAction will be removed and each derived class will be
+        // simplified.
+        // One advantage wrt today: multiple TransportService registrations are supported (today there is a bit of unbalance for "secondary"
+        // actions.
+        registerAction(
+            actions,
+            GetFieldMappingsAction.INSTANCE,
+            new TransportGetFieldMappingsAction(
+                services.transportService().getTaskManager(),
+                services.clusterService(),
+                actionFilters,
+                services.indexNameExpressionResolver(),
+                services.client()
+            )
+        ).withTransportService(services.transportService(), EsExecutors.DIRECT_EXECUTOR_SERVICE, true, GetFieldMappingsRequest::new)
+            .withNodeClient();
+
+        // actions.register(FieldCapabilitiesAction.INSTANCE, TransportFieldCapabilitiesAction.class);
+        // SOLUTION 2: registration code (mostly) inside the TransportAction implementation class
+        // SOLUTION 2A:
+        var action = new TransportFieldCapabilitiesAction(
+            services.transportService(),
+            services.clusterService(),
+            services.threadPool(),
+            actionFilters,
+            services.indicesService(),
+            services.indexNameExpressionResolver()
+        );
+        action.registerWithNodeClient((actionType, executor) -> actions.put(actionType, action));
+        action.registerWithTransport(new RegistrableTransportAction.TransportActionRegister() {
+            @Override
+            public <Request extends ActionRequest> void register(
+                String actionName,
+                Executor executor,
+                Writeable.Reader<Request> requestReader,
+                TransportRequestHandler<Request> handler
+            ) {
+                // TODO
+            }
+        });
+
+        // SOLUTION 2B: same, but with some little helper classes to make it nicer
+        // a) one registry for the whole method. Will hold call the registration code inside each TransportAction instance
+        // and populate the map need for NodeClient (or create it - no need to create it outside and pass it?)
+        ActionRegistry actionRegistry = new ActionRegistry(actions, services);
+
+        // b) for each TransportAction: create and instance and register it (with TransportService, NodeClient, or both)
+        actionRegistry.registerAction(
+            ActionRegistrar::registerWithTransportServiceAndNodeClient,
+            new TransportFieldCapabilitiesAction(
+                services.transportService(),
+                services.clusterService(),
+                services.threadPool(),
+                actionFilters,
+                services.indicesService(),
+                services.indexNameExpressionResolver()
+            )
+        );
+
+        return unmodifiableMap(actions);
+    }
+
+    private static class TransportActionRegistration<Request extends ActionRequest, Response extends ActionResponse> {
+
+        private final ActionType<Response> actionType;
+        private final TransportAction<Request, Response> transportAction;
+        private final Map<ActionType<? extends ActionResponse>, TransportAction<? extends ActionRequest, ? extends ActionResponse>> actions;
+
+        TransportActionRegistration(
+            ActionType<Response> actionType,
+            TransportAction<Request, Response> transportAction,
+            Map<ActionType<? extends ActionResponse>, TransportAction<? extends ActionRequest, ? extends ActionResponse>> actions
+        ) {
+            this.actionType = actionType;
+            this.transportAction = transportAction;
+            this.actions = actions;
+        }
+
+        TransportActionRegistration<Request, Response> withTransportService(
+            TransportService transportService,
+            Executor executor,
+            boolean canTripCircuitBreaker,
+            Writeable.Reader<Request> requestReader
+        ) {
+
+            transportService.registerRequestHandler(
+                transportAction.actionName,
+                executor,
+                false,
+                canTripCircuitBreaker,
+                requestReader,
+                (request, channel, task) -> transportAction.execute(task, request, new ChannelActionListener<>(channel))
+            );
+            return this;
+        }
+
+        void withNodeClient() {
+            actions.put(actionType, transportAction);
+        }
+    }
+
+    private static class ActionRegistrar {
+        private final Runnable registerTransportAction;
+        private final Runnable registerClientAction;
+
+        ActionRegistrar(Runnable registerTransportAction, Runnable registerClientAction) {
+            this.registerTransportAction = registerTransportAction;
+            this.registerClientAction = registerClientAction;
+        }
+
+        public void registerWithTransportService() {
+            registerTransportAction.run();
+        }
+
+        public void registerWithNodeClient() {
+            registerClientAction.run();
+        }
+
+        public void registerWithTransportServiceAndNodeClient() {
+            registerTransportAction.run();
+            registerClientAction.run();
+        }
+    }
+
+    private static class ActionRegistry {
+        private final Map<ActionType<? extends ActionResponse>, TransportAction<? extends ActionRequest, ? extends ActionResponse>> actions;
+        private final ActionServices services;
+
+        ActionRegistry(
+            Map<ActionType<? extends ActionResponse>, TransportAction<? extends ActionRequest, ? extends ActionResponse>> actions,
+            ActionServices services
+        ) {
+            this.actions = actions;
+            this.services = services;
+        }
+
+        private <Request extends ActionRequest> void registerTransportAction(
+            String actionName,
+            Executor executor,
+            Writeable.Reader<Request> requestReader,
+            TransportRequestHandler<Request> handler
+        ) {
+            services.transportService().registerRequestHandler(actionName, executor, false, true, requestReader, handler);
+        }
+
+        void registerAction(
+            Consumer<ActionRegistrar> registrationConsumer,
+            RegistrableTransportAction<? extends ActionRequest, ? extends ActionResponse> transportAction
+        ) {
+            var registrar = new ActionRegistrar(
+                () -> transportAction.registerWithTransport(this::registerTransportAction),
+                () -> transportAction.registerWithNodeClient((actionType, executor) -> actions.put(actionType, transportAction))
+            );
+
+            registrationConsumer.accept(registrar);
+        }
+    }
+
+    private static <
+        Request extends ActionRequest,
+        Response extends ActionResponse> TransportActionRegistration<Request, Response> registerAction(
+            Map<ActionType<? extends ActionResponse>, TransportAction<? extends ActionRequest, ? extends ActionResponse>> actions,
+            ActionType<Response> actionType,
+            TransportAction<Request, Response> transportAction
+        ) {
+        return new TransportActionRegistration<>(actionType, transportAction, actions);
+    }
+}

--- a/server/src/main/java/org/elasticsearch/node/Actions.java
+++ b/server/src/main/java/org/elasticsearch/node/Actions.java
@@ -257,6 +257,8 @@ class Actions {
             Consumer<ActionRegistrar> registrationConsumer,
             RegistrableTransportAction<? extends ActionRequest, ? extends ActionResponse> transportAction
         ) {
+            // TODO: here we can accept a TransporAction as second parameter and check (dynamically) for interface implementation
+            // e.g. var registerWithNodeClient = (transportAction instanceof RegistrableNodeClientAction) ? /*register code*/ : () -> {}
             var registrar = new ActionRegistrar(
                 () -> transportAction.registerWithTransport(this::registerTransportAction),
                 () -> transportAction.registerWithNodeClient((actionType, executor) -> actions.put(actionType, transportAction))

--- a/server/src/main/java/org/elasticsearch/node/Actions.java
+++ b/server/src/main/java/org/elasticsearch/node/Actions.java
@@ -20,19 +20,14 @@ import org.elasticsearch.action.admin.indices.mapping.get.GetFieldMappingsReques
 import org.elasticsearch.action.admin.indices.mapping.get.TransportGetFieldMappingsAction;
 import org.elasticsearch.action.fieldcaps.TransportFieldCapabilitiesAction;
 import org.elasticsearch.action.ingest.SimulatePipelineTransportAction;
-import org.elasticsearch.action.search.SearchTransportService;
 import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.ActionServices;
 import org.elasticsearch.action.support.ChannelActionListener;
 import org.elasticsearch.action.support.RegistrableTransportAction;
 import org.elasticsearch.action.support.TransportAction;
-import org.elasticsearch.client.internal.node.NodeClient;
-import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
-import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
-import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.plugins.ActionPlugin;
-import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportRequestHandler;
 import org.elasticsearch.transport.TransportService;
 
@@ -45,24 +40,6 @@ import java.util.function.Consumer;
 import static java.util.Collections.unmodifiableMap;
 
 class Actions {
-
-    interface ActionServices {
-        ClusterService clusterService();
-
-        ThreadPool threadPool();
-
-        TransportService transportService();
-
-        NodeService nodeService();
-
-        SearchTransportService searchTransportService();
-
-        NodeClient client();
-
-        IndexNameExpressionResolver indexNameExpressionResolver();
-
-        IndicesService indicesService();
-    }
 
     static Map<ActionType<? extends ActionResponse>, TransportAction<? extends ActionRequest, ? extends ActionResponse>> setupActions(
         List<ActionPlugin> actionPlugins,

--- a/server/src/main/java/org/elasticsearch/node/NodeConstruction.java
+++ b/server/src/main/java/org/elasticsearch/node/NodeConstruction.java
@@ -23,6 +23,7 @@ import org.elasticsearch.action.ingest.ReservedPipelineAction;
 import org.elasticsearch.action.search.SearchExecutionStatsCollector;
 import org.elasticsearch.action.search.SearchPhaseController;
 import org.elasticsearch.action.search.SearchTransportService;
+import org.elasticsearch.action.support.ActionServices;
 import org.elasticsearch.action.update.UpdateHelper;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.client.internal.node.NodeClient;
@@ -1195,11 +1196,13 @@ class NodeConstruction {
         this.pluginLifecycleComponents = Collections.unmodifiableList(pluginLifecycleComponents);
 
         final var indexNameExpressionResolver = clusterModule.getIndexNameExpressionResolver();
+
+        // Separate ActionServices and PluginServices or unify? There is a lot of overlap, but not 100%
         client.initialize(
             Actions.setupActions(
                 pluginsService.filterPlugins(ActionPlugin.class).toList(),
                 actionModule.getActionFilters(),
-                new Actions.ActionServices() {
+                new ActionServices() {
                     @Override
                     public ClusterService clusterService() {
                         return clusterService;
@@ -1238,6 +1241,21 @@ class NodeConstruction {
                     @Override
                     public IndicesService indicesService() {
                         return indicesService;
+                    }
+
+                    @Override
+                    public ScriptService scriptService() {
+                        return scriptService;
+                    }
+
+                    @Override
+                    public Environment environment() {
+                        return environment;
+                    }
+
+                    @Override
+                    public ResourceWatcherService resourceWatcherService() {
+                        return resourceWatcherService;
                     }
                 }
             ),

--- a/server/src/main/java/org/elasticsearch/plugins/ActionPlugin.java
+++ b/server/src/main/java/org/elasticsearch/plugins/ActionPlugin.java
@@ -15,6 +15,9 @@ import org.elasticsearch.action.RequestValidators;
 import org.elasticsearch.action.admin.indices.alias.IndicesAliasesRequest;
 import org.elasticsearch.action.admin.indices.mapping.put.PutMappingRequest;
 import org.elasticsearch.action.support.ActionFilter;
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.ActionRegistrar;
+import org.elasticsearch.action.support.ActionServices;
 import org.elasticsearch.action.support.TransportAction;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
@@ -50,6 +53,12 @@ public interface ActionPlugin {
      */
     default List<ActionHandler<? extends ActionRequest, ? extends ActionResponse>> getActions() {
         return Collections.emptyList();
+    }
+
+    default void registerActions(
+        ActionFilters actionFilters,
+        ActionServices services,
+        ActionRegistrar actionRegistrar) {
     }
 
     /**


### PR DESCRIPTION
This is a second take at making `NodeClient` execute actions on the correct executor. Well, it opens the way to it to be more precise.
It is an alternative to https://github.com/elastic/elasticsearch/pull/100895 and it was born out of the discussion over that PR.

It starts with a new `Actions` class, which ideally can be internal to `NodeConstructor` and private (but I kept it in a separate file - package private - for readability reasons).
The goal of this class is to replace `ActionModule#setupActions` and `HandledTransportAction` (in particular the ctor which does `transportService.registerRequestHandler`). This way we should be able to avoid the usage of injection altogether. Injection is used today to create the `TransportAction` instances, to create the `ActionType -> TransportAction` map used by `NodeClient`, and to pass it from `ActionModule` to `NodeClient`.

At `NodeClient` intialization, instead of getting the action map from injection, we build it directly using the new `Actions` class.
This seems to me like a good place, as we have already got all the services we need to instantiate the various `TransportAction` classes.

The `Actions` class instantiate them directly, and put them in a map. This is provisional - to keep changes minimal. From here we can further expand, e.g. by building a more complex map that includes the desired Executor, or devise some other way to initialize NodeClient and pass all the necessary information. 

The code in this PR shows 2  different steps, and 2 different solutions for the second step (alternative solutions).
They are clearly marked with comments inside the `Actions` class.

Step 1 just gets rid of the injector. Step 2 also registers `TransportAction`s with TransportService (replacing `HandledTransportAction`).

The first solution for Step 2 does this by keeping the registration code in `Actions`. As a consequence `TransportAction` classes are simplified, but registration code and action implementation are "far" away.

The second solution for Step 2 keeps the registration code in the `TransportAction` classes; this code setup a "capabillity" to register, and it is later called by `Actions`, which actually decides to register the action with TransportService, with NodeClient, or both. We can change it and make it always call registration on `TransportAction` for both (but have no-op registration functions for what we do not want to register) and/or separate interfaces, and base our registration code on those. I have a couple of ideas but did not want to get ahead of myself and run this with you to see if you liked the approach. 

Personally I like the second solution: it looks pretty neat:
```
actionRegistry.registerAction(
            ActionRegistrar::registerWithTransportServiceAndNodeClient,
            new TransportFieldCapabilitiesAction(
                services.transportService(),
                services.clusterService(),
                services.threadPool(),
                actionFilters,
                services.indicesService(),
                services.indexNameExpressionResolver()
            )
        );
```
We can further improve names, and/or add more automation based on types/interfaces and get rid of the first parameter and be even neater :)